### PR TITLE
Add file naming check

### DIFF
--- a/.github/scripts/check.sh
+++ b/.github/scripts/check.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Check file naming convention of challenges.
+#
+# Usage:
+#     check.sh May-LeetCoding-Challenge
+#
+cd "$(dirname ${BASH_SOURCE})"/../..
+
+challenge_dir="${PWD}/${1}"
+errors=0
+
+echo "Checking ${challenge_dir}"
+echo
+
+for question_path in $challenge_dir/*
+do
+    dirname="${question_path##*/}"  # remove parent directoris
+    question="${dirname#*-}"        # remove leading day prefix
+    echo "Question ${dirname}:"
+
+    for filepath in $question_path/*
+    do
+        filename="${filepath##*/}"
+        if [[ "${filename}" == "${question}"* || "$filename" == "README.md" ]]
+        then
+            echo "  PASSED: ${filename}"
+        else
+            echo "  FAILED: ${filename}"
+            errors=$((errors + 1))
+        fi
+    done
+    echo
+done
+
+if [ "$errors" -gt 0 ]
+then
+    cat << EOF
+Check failed with ${errors} errors detected. Please check the console
+output above and follow naming convention:
+
+    \${question}.\${language}
+
+EOF
+    exit 1
+fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+#
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+#
+name: Actions
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check file naming
+      run: .github/scripts/check.sh May-LeetCoding-Challenge


### PR DESCRIPTION
To improve readability, I suggest improving the naming convention of solutions. All solutions submitted in May-LeetCoding-Challenge should be named using the name of the question (directory without the day prefix), followed by the language suffix. The only exception is the `README.md` file. All submissions without respecting the convention will fail in the CI.

```
Question 01-First-Bad-Version:
  PASSED: First-Bad-Version.cpp
  PASSED: First-Bad-Version.go
  PASSED: First-Bad-Version.java
  PASSED: First-Bad-Version.js
  PASSED: First-Bad-Version.py
  PASSED: First-Bad-Version.scala
  FAILED: FirstBadVersionKotlin278.kt
  PASSED: README.md

Question 02-Jewels-And-Stones:
  PASSED: Jewels-And-Stones.java
  FAILED: Jewels-and-Stones.cpp
  FAILED: Jewels-and-Stones.py
  FAILED: Jewels-and-Stones.scala
  FAILED: JewelsandStonesKotlin771.kt
```

Clicking the commit status will see the result in GitHub actions.